### PR TITLE
Don't crash on empty JSON strings

### DIFF
--- a/lib/linter-crystal.js
+++ b/lib/linter-crystal.js
@@ -49,6 +49,7 @@ export default {
         args.push('-f', 'json')
         args.push(activeEditor.getPath())
         resolve(helpers.exec(command, args).then(output => {
+          if (!output) return []
           const result = []
           for (issue of JSON.parse(output)) {
             result.push({
@@ -56,7 +57,7 @@ export default {
               text: issue.message,
               filePath: issue.file,
               range: [
-                [issue.line - 1, issue.column -1 ],
+                [issue.line - 1, issue.column - 1],
                 [issue.line - 1, issue.column + issue.size - 1]
               ]
             })

--- a/spec/files/without_errors.cr
+++ b/spec/files/without_errors.cr
@@ -1,0 +1,1 @@
+puts "Hello, World!"

--- a/spec/linter-crystal-spec.js
+++ b/spec/linter-crystal-spec.js
@@ -9,6 +9,16 @@ describe('The Crystal provider for AtomLinter', () => {
     })
   })
 
+  it('does not find any errors in "without_errors.cr"', () => {
+    waitsForPromise(() => {
+      return atom.workspace.open(__dirname + '/files/without_errors.cr').then(editor => {
+        return lint(editor).then(messages => {
+          expect(messages.length).toEqual(0)
+        })
+      })
+    })
+  })
+
   it('finds an error in "incorrect_method_type.cr"', () => {
     waitsForPromise(() => {
       return atom.workspace.open(__dirname + '/files/incorrect_method_type.cr').then(editor => {


### PR DESCRIPTION
This fixes an issue which causes the following error when the edited crystal source file contains no errors:

```
SyntaxError: Unexpected end of input
  at Object.parse (native)
  at /home/pgkos/.atom/packages/linter-crystal/lib/linter-crystal.js:59:32
```
