### PR TITLE
Change default compilation command from 'build' to 'compile'

### DIFF
--- a/lib/linter-crystal.js
+++ b/lib/linter-crystal.js
@@ -24,7 +24,7 @@ export default {
       title: 'Compiler Command',
       description: 'The command passed to the commpiler during linting.',
       type: 'string',
-      default: 'build'
+      default: 'compile'
     }
   },
 


### PR DESCRIPTION
See: https://github.com/crystal-lang/crystal/issues/502

Using "build" right now produces a huge compiler warning about it being deprecated.
