### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/linter-crystal.js
+++ b/lib/linter-crystal.js
@@ -1,11 +1,11 @@
 'use babel';
 
 export default {
-  activate: () => {
+  activate() {
     atom.notifications.addWarning('`linter-crstal` has been deprecated in favor of the new package `crystal`')
   },
 
-  provideLinter: () => {
+  provideLinter() {
     return {
       name: 'Crystal',
       grammarScopes: ['source.crystal'],


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.